### PR TITLE
Fix textfield focus border color

### DIFF
--- a/build/ignition.css
+++ b/build/ignition.css
@@ -832,7 +832,7 @@ hr {
 }
 
 .c-textfield:focus {
-  border-color: #004c8f;
+  border-color: #0062b8;
   outline: 0;
   box-shadow: 0 0 0 3px #99cfff;
 }

--- a/source/components/_textfield.scss
+++ b/source/components/_textfield.scss
@@ -15,7 +15,7 @@
   background-color: $color-white-regular;
 
   &:focus {
-    border-color: $color-primary-dark-1;
+    border-color: $color-primary-regular;
     // Mind that the outline should be removed only if other styles that imply
     // focus are set.
     outline: 0;


### PR DESCRIPTION
Valid and invalid states use a standard color to style borders on focus so there's no need to have a darker variant for the default component.