### PR TITLE
Extend card component

### DIFF
--- a/build/ignition.css
+++ b/build/ignition.css
@@ -874,6 +874,13 @@ hr {
   line-height: 1.33333333;
 }
 
+.c-card__media {
+  max-width: calc(100% + 2 * 1.5rem);
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  margin: -1.5rem -1.5rem 1.5rem;
+}
+
 .c-notice {
   padding: 1rem 1.5rem;
   border-radius: 4px;

--- a/source/components/_card.scss
+++ b/source/components/_card.scss
@@ -15,3 +15,10 @@
     font-size: $font-size-large-3;
     line-height: $line-height-small-1;
   }
+
+  .c-card__media {
+    max-width: calc(100% + 2 * #{$space-large-4});
+    border-top-left-radius: $border-radius-regular;
+    border-top-right-radius: $border-radius-regular;
+    margin: (-$space-large-4) (-$space-large-4) $space-large-4;
+  }

--- a/source/components/_card.scss
+++ b/source/components/_card.scss
@@ -17,8 +17,11 @@
   }
 
   .c-card__media {
+    // Override maximum width from embedding basics so that this item can span
+    // the entire parent width.
     max-width: calc(100% + 2 * #{$space-large-4});
     border-top-left-radius: $border-radius-regular;
     border-top-right-radius: $border-radius-regular;
+    // Use parentheses to prevent mathematical operations.
     margin: (-$space-large-4) (-$space-large-4) $space-large-4;
   }


### PR DESCRIPTION
Card content can vary from just a heading and paragraph to more complex compositions containing images, text, lists, and buttons. The component should accommodate all these items in any sensible arrangement.