### PR TITLE
Remove bottom margin from last notice paragraph

### DIFF
--- a/build/ignition.css
+++ b/build/ignition.css
@@ -898,6 +898,10 @@ hr {
   background-color: whitesmoke;
 }
 
+.c-notice p:last-child {
+  margin-bottom: 0;
+}
+
 .c-notice--dismissable {
   position: relative;
   padding-right: 3rem;

--- a/source/components/_notice.scss
+++ b/source/components/_notice.scss
@@ -9,6 +9,11 @@
   background-color: $color-neutral-light-1;
 }
 
+  .c-notice p:last-child {
+    // Remove bottom margin because of existing padding.
+    margin-bottom: 0;
+  }
+
 // Dismissable notice
 
 .c-notice--dismissable {


### PR DESCRIPTION
The notice component has padding set up to prevent items from touching the edges so the default paragraph bottom margin would create a large space at the bottom.