### PR TITLE
Add warning notice

### DIFF
--- a/build/ignition.css
+++ b/build/ignition.css
@@ -982,6 +982,27 @@ hr {
   background-color: #043d00;
 }
 
+.c-notice--warning {
+  color: #8f5f00;
+  background-color: #fff8eb;
+}
+
+.c-notice--warning .c-notice__dismiss {
+  background-color: #ffeac2;
+}
+
+.c-notice--warning .c-notice__dismiss:hover {
+  background-color: #664400;
+}
+
+.c-notice--warning .c-notice__dismiss:focus {
+  box-shadow: 0 0 0 3px #ffdd99;
+}
+
+.c-notice--warning .c-notice__dismiss:active {
+  background-color: #523600;
+}
+
 .c-notice--negative {
   color: #a30b00;
   background-color: #ffeceb;

--- a/source/components/_notice.scss
+++ b/source/components/_notice.scss
@@ -103,6 +103,29 @@
     }
   }
 
+// Warning notice
+
+.c-notice--warning {
+  color: $color-warning-regular;
+  background-color: $color-warning-light-1;
+}
+
+  .c-notice--warning .c-notice__dismiss {
+    background-color: $color-warning-light-3;
+
+    &:hover {
+      background-color: $color-warning-dark-1;
+    }
+
+    &:focus {
+      box-shadow: $box-shadow-regular $color-warning-light-4;
+    }
+
+    &:active {
+      background-color: $color-warning-dark-2;
+    }
+  }
+
 // Negative notice
 
 .c-notice--negative {


### PR DESCRIPTION
Warning notices should be used to provide feedback on conditions that might cause problems in the future.