### PR TITLE
Simplify container organizer

### DIFF
--- a/build/ignition.css
+++ b/build/ignition.css
@@ -1025,8 +1025,11 @@ hr {
 }
 
 .o-container {
+  max-width: 1240px;
   padding-right: 1.25rem;
   padding-left: 1.25rem;
+  margin-right: auto;
+  margin-left: auto;
 }
 
 @media screen and (min-width: 720px) {
@@ -1034,12 +1037,6 @@ hr {
     padding-right: 2.5rem;
     padding-left: 2.5rem;
   }
-}
-
-.o-container--limited {
-  max-width: 1240px;
-  margin-right: auto;
-  margin-left: auto;
 }
 
 .o-segment {

--- a/source/organizers/_container.scss
+++ b/source/organizers/_container.scss
@@ -3,20 +3,15 @@
 // -----------------------------------------------------------------------------
 
 .o-container {
+  max-width: $content-max-width;
   padding-right: $space-large-5;
   padding-left: $space-large-5;
+  margin-right: auto;
+  margin-left: auto;
 
   @include media(m) {
     // Increase padding to distance content from screen edges.
     padding-right: $space-large-5 * 2;
     padding-left: $space-large-5 * 2;
   }
-}
-
-// Limited container
-
-.o-container--limited {
-  max-width: $content-max-width;
-  margin-right: auto;
-  margin-left: auto;
 }


### PR DESCRIPTION
Having a separate variant that establishes the maximum width and centers content unnecessarily complicates container use.