### PR TITLE
Rename $border-radius-round to $border-radius-full

### DIFF
--- a/source/components/_radio.scss
+++ b/source/components/_radio.scss
@@ -6,7 +6,7 @@
   width: 1.25rem;
   height: 1.25rem;
   border: $border-width-regular solid $color-neutral-light-4;
-  border-radius: $border-radius-round;
+  border-radius: $border-radius-full;
   margin-right: $space-small-5;
   vertical-align: middle;
   // Allow complete styling in all browsers.

--- a/source/components/_tag.scss
+++ b/source/components/_tag.scss
@@ -5,7 +5,7 @@
 .c-tag {
   display: inline-block;
   padding: $space-small-4 $space-small-1;
-  border-radius: $border-radius-round;
+  border-radius: $border-radius-full;
   color: $color-neutral-regular;
   background-color: $color-neutral-light-2;
 }

--- a/source/settings/_decoration.scss
+++ b/source/settings/_decoration.scss
@@ -14,7 +14,7 @@ $border-width-thick: 4px;
 // Provide a standard border radius.
 $border-radius-regular: 4px;
 // Provide a border radius that produces fully rounded corners.
-$border-radius-round: 720px;
+$border-radius-full: 720px;
 
 // Box shadow
 

--- a/source/utilities/_border.scss
+++ b/source/utilities/_border.scss
@@ -4,7 +4,7 @@
 
 $border-radius-values: (
   regular: $border-radius-regular,
-  round: $border-radius-round
+  round: $border-radius-full
 );
 
 @include utility(border-radius, $border-radius-values);


### PR DESCRIPTION
Avoid confusion and ease name recall by using the same adjective for all variables that establish a maximum value.