### PR TITLE
Rename neutral colors to gray

### DIFF
--- a/source/basics/_common.scss
+++ b/source/basics/_common.scss
@@ -26,6 +26,6 @@ body {
   font-family: $font-family-regular;
   font-size: $font-size-regular;
   line-height: $line-height-regular;
-  color: $color-neutral-regular;
+  color: $color-gray-regular;
   background-color: $color-white-regular;
 }

--- a/source/basics/_grouping.scss
+++ b/source/basics/_grouping.scss
@@ -44,7 +44,7 @@ table {
     // Employ `calc()` to ensure precise alignment with items that use the same
     // spacing values but lack a border.
     padding: $space-small-1 $space-regular calc(#{$space-small-1} - #{$border-width-regular});
-    border-bottom: $border-width-regular solid $color-neutral-light-3;
+    border-bottom: $border-width-regular solid $color-gray-light-3;
     vertical-align: top;
   }
 
@@ -61,7 +61,7 @@ table {
     // Employ `calc()` to ensure precise alignment with items that use the same
     // spacing values but lack a border.
     padding-bottom: calc(#{$space-small-1} - #{$border-width-regular});
-    border-bottom: $border-width-regular solid $color-neutral-light-3;
+    border-bottom: $border-width-regular solid $color-gray-light-3;
     font-size: $font-size-large-5;
     font-weight: bold;
     text-align: left;
@@ -96,5 +96,5 @@ hr {
   border: 0;
   margin-top: $space-large-2;
   margin-bottom: $space-large-2;
-  background-color: $color-neutral-light-3;
+  background-color: $color-gray-light-3;
 }

--- a/source/basics/_text.scss
+++ b/source/basics/_text.scss
@@ -119,12 +119,12 @@ kbd {
 }
 
 code {
-  background-color: $color-neutral-light-2;
+  background-color: $color-gray-light-2;
 }
 
 kbd {
   color: $color-white-regular;
-  background-color: $color-neutral-regular;
+  background-color: $color-gray-regular;
 
   kbd {
     // Remove unwanted custom styles from nested user input elements.
@@ -138,7 +138,7 @@ kbd {
 mark {
   padding: 0.125em 0.25em;
   border-radius: $border-radius-regular;
-  color: $color-neutral-regular;
+  color: $color-gray-regular;
 }
 
 // Small

--- a/source/components/_button.scss
+++ b/source/components/_button.scss
@@ -15,28 +15,28 @@
   text-align: center;
   // Prevent text wrapping, usually in a flex context.
   white-space: nowrap;
-  color: $color-neutral-regular;
-  background-color: $color-neutral-light-2;
+  color: $color-gray-regular;
+  background-color: $color-gray-light-2;
 
   &:hover {
-    background-color: $color-neutral-light-4;
+    background-color: $color-gray-light-4;
   }
 
   &:focus {
     // Mind that the outline should be removed only if other styles that imply
     // focus are set.
     outline: 0;
-    box-shadow: $box-shadow-regular $color-neutral-light-6;
+    box-shadow: $box-shadow-regular $color-gray-light-6;
   }
 
   &:active {
-    background-color: $color-neutral-light-5;
+    background-color: $color-gray-light-5;
   }
 
   &:disabled,
   &.is-disabled {
     opacity: $opacity-low;
-    background-color: $color-neutral-light-2;
+    background-color: $color-gray-light-2;
     box-shadow: none;
     cursor: default;
   }
@@ -154,60 +154,60 @@
 
 .c-button--neutral {
   color: $color-white-regular;
-  background-color: $color-neutral-regular;
+  background-color: $color-gray-regular;
 
   &:hover {
-    background-color: $color-neutral-dark-1;
+    background-color: $color-gray-dark-1;
   }
 
   &:focus {
-    box-shadow: $box-shadow-regular $color-neutral-light-5;
+    box-shadow: $box-shadow-regular $color-gray-light-5;
   }
 
   &:active {
-    background-color: $color-neutral-dark-2;
+    background-color: $color-gray-dark-2;
   }
 }
 
 .c-button--neutral-outlined {
-  border-color: $color-neutral-regular;
-  color: $color-neutral-regular;
+  border-color: $color-gray-regular;
+  color: $color-gray-regular;
   background-color: transparent;
 
   &:hover {
-    background-color: $color-neutral-light-2;
+    background-color: $color-gray-light-2;
   }
 
   &:focus {
-    box-shadow: $box-shadow-regular $color-neutral-light-5;
+    box-shadow: $box-shadow-regular $color-gray-light-5;
   }
 
   &:active {
-    background-color: $color-neutral-light-3;
+    background-color: $color-gray-light-3;
   }
 }
 
 .c-button--neutral-plain {
-  color: $color-neutral-regular;
+  color: $color-gray-regular;
   background-color: transparent;
 
   &:hover {
-    background-color: $color-neutral-light-2;
+    background-color: $color-gray-light-2;
   }
 
   &:focus {
-    box-shadow: $box-shadow-regular $color-neutral-light-5;
+    box-shadow: $box-shadow-regular $color-gray-light-5;
   }
 
   &:active {
-    background-color: $color-neutral-light-3;
+    background-color: $color-gray-light-3;
   }
 }
 
 // Inverse buttons
 
 .c-button--inverse {
-  color: $color-neutral-regular;
+  color: $color-gray-regular;
   background-color: $color-white-regular;
 
   &:hover {
@@ -266,7 +266,7 @@
 .c-button--neutral {
   &:disabled,
   &.is-disabled {
-    background-color: $color-neutral-regular;
+    background-color: $color-gray-regular;
     box-shadow: none;
   }
 }
@@ -284,8 +284,8 @@
 .c-button--neutral-outlined {
   &:disabled,
   &.is-disabled {
-    border-color: $color-neutral-regular;
-    color: $color-neutral-regular;
+    border-color: $color-gray-regular;
+    color: $color-gray-regular;
     background-color: transparent;
     box-shadow: none;
   }
@@ -306,7 +306,7 @@
 .c-button--neutral-plain {
   &:disabled,
   &.is-disabled {
-    color: $color-neutral-regular;
+    color: $color-gray-regular;
     background-color: transparent;
     box-shadow: none;
   }

--- a/source/components/_card.scss
+++ b/source/components/_card.scss
@@ -6,7 +6,7 @@
   // Employ `calc()` to ensure precise alignment with items that use the same
   // spacing values but lack a border.
   padding: calc(#{$space-large-4} - #{$border-width-regular});
-  border: $border-width-regular solid $color-neutral-light-4;
+  border: $border-width-regular solid $color-gray-light-4;
   border-radius: $border-radius-regular;
 }
 

--- a/source/components/_checkbox.scss
+++ b/source/components/_checkbox.scss
@@ -5,7 +5,7 @@
 .c-checkbox {
   width: 1.25rem;
   height: 1.25rem;
-  border: $border-width-regular solid $color-neutral-light-4;
+  border: $border-width-regular solid $color-gray-light-4;
   border-radius: $border-radius-regular;
   margin-right: $space-small-5;
   vertical-align: middle;
@@ -29,8 +29,8 @@
   }
 
   &:disabled {
-    border-color: $color-neutral-regular;
-    background-color: $color-neutral-regular;
+    border-color: $color-gray-regular;
+    background-color: $color-gray-regular;
 
     // Style `label` element adjacent to a disabled checkbox.
     & + label {

--- a/source/components/_list.scss
+++ b/source/components/_list.scss
@@ -12,7 +12,7 @@
   }
 
     .c-list__link {
-      color: $color-neutral-regular;
+      color: $color-gray-regular;
 
       &:hover {
         color: $color-primary-regular;

--- a/source/components/_nav.scss
+++ b/source/components/_nav.scss
@@ -11,7 +11,7 @@
   .c-nav__link {
     display: inline-block;
     padding: $space-small-2 $space-regular;
-    color: $color-neutral-regular;
+    color: $color-gray-regular;
 
     &:hover {
       color: $color-primary-regular;

--- a/source/components/_notice.scss
+++ b/source/components/_notice.scss
@@ -5,8 +5,8 @@
 .c-notice {
   padding: $space-regular $space-large-4;
   border-radius: $border-radius-regular;
-  color: $color-neutral-regular;
-  background-color: $color-neutral-light-1;
+  color: $color-gray-regular;
+  background-color: $color-gray-light-1;
 }
 
   .c-notice p:last-child {
@@ -29,23 +29,23 @@
     border-top-right-radius: $border-radius-regular;
     border-bottom-left-radius: $border-radius-regular;
     color: inherit;
-    background-color: $color-neutral-light-3;
+    background-color: $color-gray-light-3;
 
     &:hover {
       color: $color-white-regular;
-      background-color: $color-neutral-dark-1;
+      background-color: $color-gray-dark-1;
     }
 
     &:focus {
       // Mind that the outline should be removed only if other styles that imply
       // focus are set.
       outline: 0;
-      box-shadow: $box-shadow-regular $color-neutral-light-5;
+      box-shadow: $box-shadow-regular $color-gray-light-5;
     }
 
     &:active {
       color: $color-white-regular;
-      background-color: $color-neutral-dark-2;
+      background-color: $color-gray-dark-2;
     }
   }
 

--- a/source/components/_radio.scss
+++ b/source/components/_radio.scss
@@ -5,7 +5,7 @@
 .c-radio {
   width: 1.25rem;
   height: 1.25rem;
-  border: $border-width-regular solid $color-neutral-light-4;
+  border: $border-width-regular solid $color-gray-light-4;
   border-radius: $border-radius-full;
   margin-right: $space-small-5;
   vertical-align: middle;
@@ -29,8 +29,8 @@
   }
 
   &:disabled {
-    border-color: $color-neutral-regular;
-    background-color: $color-neutral-regular;
+    border-color: $color-gray-regular;
+    background-color: $color-gray-regular;
 
     // Style `label` element adjacent to a disabled radio.
     & + label {

--- a/source/components/_tabs.scss
+++ b/source/components/_tabs.scss
@@ -5,7 +5,7 @@
 .c-tabs {
   @include list-reset;
   display: flex;
-  border-bottom: $border-width-regular solid $color-neutral-light-2;
+  border-bottom: $border-width-regular solid $color-gray-light-2;
   margin-bottom: 0;
 }
 
@@ -13,7 +13,7 @@
     display: inline-block;
     padding: $space-small-2 $space-regular;
     margin-bottom: -#{$border-width-regular};
-    color: $color-neutral-regular;
+    color: $color-gray-regular;
 
     &:hover {
       color: $color-primary-regular;

--- a/source/components/_tag.scss
+++ b/source/components/_tag.scss
@@ -6,19 +6,19 @@
   display: inline-block;
   padding: $space-small-4 $space-small-1;
   border-radius: $border-radius-full;
-  color: $color-neutral-regular;
-  background-color: $color-neutral-light-2;
+  color: $color-gray-regular;
+  background-color: $color-gray-light-2;
 }
 
 // Interactive tag
 
 .c-tag--interactive {
   &:hover {
-    background-color: $color-neutral-light-4;
+    background-color: $color-gray-light-4;
   }
 
   &:active {
-    background-color: $color-neutral-light-5;
+    background-color: $color-gray-light-5;
   }
 }
 

--- a/source/components/_textfield.scss
+++ b/source/components/_textfield.scss
@@ -7,11 +7,11 @@
   // Employ `calc()` to ensure precise alignment with items that use the same
   // spacing values but lack a border.
   padding: calc(#{$space-small-2} - #{$border-width-regular}) calc(#{$space-regular} - #{$border-width-regular});
-  border: $border-width-regular solid $color-neutral-light-4;
+  border: $border-width-regular solid $color-gray-light-4;
   border-radius: $border-radius-regular;
   font-size: $font-size-regular;
   line-height: $line-height-regular;
-  color: $color-neutral-regular;
+  color: $color-gray-regular;
   background-color: $color-white-regular;
 
   &:focus {
@@ -41,7 +41,7 @@
 
   // Normalize selected option text from focused `select` elements in Edge.
   &:focus::-ms-value {
-    color: $color-neutral-regular;
+    color: $color-gray-regular;
     background-color: $color-white-regular;
   }
 }

--- a/source/settings/_color.scss
+++ b/source/settings/_color.scss
@@ -28,20 +28,20 @@ $color-negative-light-4: change-color($color-negative-regular, $lightness: 84%);
 $color-negative-dark-1: adjust-color($color-negative-regular, $lightness: -8%);
 $color-negative-dark-2: adjust-color($color-negative-regular, $lightness: -12%);
 
-// Neutral
+// Gray
 
-// Provide a standard neutral color.
-$color-neutral-regular: #3d3d3d;
-// Provide lighter than standard neutral colors.
-$color-neutral-light-1: change-color($color-neutral-regular, $lightness: 96%);
-$color-neutral-light-2: change-color($color-neutral-regular, $lightness: 92%);
-$color-neutral-light-3: change-color($color-neutral-regular, $lightness: 88%);
-$color-neutral-light-4: change-color($color-neutral-regular, $lightness: 84%);
-$color-neutral-light-5: change-color($color-neutral-regular, $lightness: 80%);
-$color-neutral-light-6: change-color($color-neutral-regular, $lightness: 76%);
-// Provide darker than standard neutral colors.
-$color-neutral-dark-1: adjust-color($color-neutral-regular, $lightness: -8%);
-$color-neutral-dark-2: adjust-color($color-neutral-regular, $lightness: -12%);
+// Provide a standard gray color.
+$color-gray-regular: #3d3d3d;
+// Provide lighter than standard gray colors.
+$color-gray-light-1: change-color($color-gray-regular, $lightness: 96%);
+$color-gray-light-2: change-color($color-gray-regular, $lightness: 92%);
+$color-gray-light-3: change-color($color-gray-regular, $lightness: 88%);
+$color-gray-light-4: change-color($color-gray-regular, $lightness: 84%);
+$color-gray-light-5: change-color($color-gray-regular, $lightness: 80%);
+$color-gray-light-6: change-color($color-gray-regular, $lightness: 76%);
+// Provide darker than standard gray colors.
+$color-gray-dark-1: adjust-color($color-gray-regular, $lightness: -8%);
+$color-gray-dark-2: adjust-color($color-gray-regular, $lightness: -12%);
 
 // White
 


### PR DESCRIPTION
Along with white, gray is a supporting color and variables that define them should be declarative.

See #56 for details.