### PR TITLE
Correct card cover comments

### DIFF
--- a/source/components/_card.scss
+++ b/source/components/_card.scss
@@ -17,10 +17,9 @@
   }
 
   .c-card__cover {
-    // Allow negative right margin on items that are inline by default.
     display: block;
-    // Override established maximum width and match card width on `img`,
-    // `video`, and `audio` elements.
+    // Override established maximum width and match card width on `img` and
+    // `video` elements.
     max-width: calc(100% + 2 * #{$space-large-4});
     margin-right: -$space-large-4;
     margin-bottom: $space-large-4;


### PR DESCRIPTION
Simplify comments on the card component cover descendant.