### PR TITLE
Simplify build process

### DIFF
--- a/build/styles/ignition.css
+++ b/build/styles/ignition.css
@@ -11,8 +11,7 @@ html {
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
-    sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 1rem;
   line-height: 1.5;
   color: #333333;
@@ -359,8 +358,7 @@ sup {
   background-color: #141414;
 }
 
-.c-button:disabled,
-.c-button.is-disabled {
+.c-button:disabled, .c-button.is-disabled {
   opacity: 0.5;
   pointer-events: none;
 }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,11 @@
   "license": "MIT",
   "scripts": {
     "compile:sass": "node-sass --output build/styles/ source/ignition.scss --output-style expanded --precision 8",
-    "format:css": "prettier --write build/styles/ignition.css",
     "minify:css": "cleancss --output build/styles/ignition.min.css build/styles/ignition.css",
-    "build:all": "npm run compile:sass && npm run format:css && npm run minify:css"
+    "build:all": "npm run compile:sass && npm run minify:css"
   },
   "devDependencies": {
     "node-sass": "^4.7.2",
-    "prettier": "^1.14.3",
     "clean-css-cli": "^4.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "compile:sass": "node-sass --output-style expanded --precision 8 --output build/styles/ source/ignition.scss",
+    "compile:sass": "node-sass --output build/styles/ source/ignition.scss --output-style expanded --precision 8",
     "format:css": "prettier --write build/styles/ignition.css",
     "minify:css": "cleancss --output build/styles/ignition.min.css build/styles/ignition.css",
     "build:all": "npm run compile:sass && npm run format:css && npm run minify:css"


### PR DESCRIPTION
Best keep the number of dependencies to a minimum so as not to overwhelm users and provide a simple starting point. Going forward, as a rule of thumb, employ a separate tool for each task: one for compiling Sass, one for minifying CSS, etc.

Mind that upcoming Javascript changes will likely require new build steps.