### PR TITLE
Rename responsive tools

### DIFF
--- a/source/helpers/query.scss
+++ b/source/helpers/query.scss
@@ -1,23 +1,23 @@
-// MEDIA
+// QUERY
 // Generate media queries.
 // -----------------------------------------------------------------------------
 
-// Use as argument a media query name established via responsive settings.
+// Use as argument a media query name established via media settings.
 // Example:
-// @include media(m) {
+// @include query(m) {
 //   margin-right: 1rem;
 // }
 // will output:
 // @media screen and (min-width: 720px) {
 //   margin-right: 1rem;
 // }
-@mixin media($query-name) {
+@mixin query($query-name) {
   @if map-has-key($queries, $query-name) {
     $query: map-get($queries, $query-name);
     @media #{$query} {
       @content;
     }
   } @else {
-    @error "No query named `#{$query-name}` found. Check spelling or review responsive settings.";
+    @error "No query named `#{$query-name}` found. Check spelling or review media settings.";
   }
 }

--- a/source/helpers/utility.scss
+++ b/source/helpers/utility.scss
@@ -17,7 +17,7 @@
 //   margin-right: 1rem !important;
 // }
 // Pass property values via nested maps to generate responsive utilities. Use a
-// media query name established via responsive settings to generate responsive
+// media query name established via media settings to generate responsive
 // utilities or the `all` keyword to generate all possible non-responsive and
 // responsive utilities.
 // Example:
@@ -75,7 +75,7 @@
         // Get media query names.
         $query-names: if(map-has-key($queries, $key), $key, map-keys($queries));
         @each $query-name in $query-names {
-          @include media($query-name) {
+          @include query($query-name) {
             @if (type-of($key-values) == map) {
               // Generate responsive utilities designated using property value
               // aliases (e.g., `.u-margin-right-regular@m`).

--- a/source/ignition.scss
+++ b/source/ignition.scss
@@ -5,7 +5,7 @@
 @import "settings/color";
 @import "settings/decoration";
 @import "settings/layout";
-@import "settings/responsive";
+@import "settings/media";
 @import "settings/spacing";
 @import "settings/typography";
 
@@ -13,7 +13,7 @@
 // Provide ways to carry out recurring tasks.
 // -----------------------------------------------------------------------------
 
-@import "helpers/media";
+@import "helpers/query";
 @import "helpers/utility";
 
 // BASICS

--- a/source/organizers/container.scss
+++ b/source/organizers/container.scss
@@ -9,7 +9,7 @@
   margin-right: auto;
   margin-left: auto;
 
-  @include media(m) {
+  @include query(m) {
     // Increase padding to distance content from screen edges.
     padding-right: $space-large-5 * 2;
     padding-left: $space-large-5 * 2;

--- a/source/organizers/grid.scss
+++ b/source/organizers/grid.scss
@@ -5,7 +5,7 @@
 .o-grid {
   display: grid;
 
-  @include media(m) {
+  @include query(m) {
     grid-template-columns: repeat($grid-columns, 1fr);
   }
 }
@@ -17,7 +17,7 @@
 
   $query-names: map-keys($queries);
   @each $query-name in $query-names {
-    @include media($query-name) {
+    @include query($query-name) {
       .o-grid__column-#{$i}\@#{$query-name} {
         grid-column: span #{$i};
       }
@@ -30,7 +30,7 @@
 .o-grid--spaced {
   grid-gap: $grid-gap-regular;
 
-  @include media(m) {
+  @include query(m) {
     grid-gap: $grid-gap-large;
   }
 }

--- a/source/organizers/lineup.scss
+++ b/source/organizers/lineup.scss
@@ -11,7 +11,7 @@
 .o-lineup__item {
   width: 100%;
 
-  @include media(m) {
+  @include query(m) {
     // Cause item to take up the specified proportion of available space. It
     // will be equal to other items on the same line that are styled this way.
     flex: 1;

--- a/source/organizers/segment.scss
+++ b/source/organizers/segment.scss
@@ -6,7 +6,7 @@
   padding-top: $space-large-2;
   padding-bottom: $space-large-2;
 
-  @include media(m) {
+  @include query(m) {
     padding-top: $space-large-1;
     padding-bottom: $space-large-1;
   }

--- a/source/settings/media.scss
+++ b/source/settings/media.scss
@@ -1,6 +1,6 @@
-// RESPONSIVE
-// Identify device types and viewport features that mark a change in the way
-// content is presented.
+// MEDIA
+// Identify device types and features that mark a change in the way content is
+// presented.
 // -----------------------------------------------------------------------------
 
 // Queries


### PR DESCRIPTION
Rename `responsive.scss` to `media.scss` to better convey that media queries are defined there. This means that the media helper also has to be renamed.