### PR TITLE
Remove unnecessary light neutral color variant

### DIFF
--- a/source/settings/color.scss
+++ b/source/settings/color.scss
@@ -37,7 +37,6 @@ $color-neutral-regular: hsl(0, 0%, 24%);
 $color-neutral-light-a: hsl(0, 0%, 96%);
 $color-neutral-light-b: hsl(0, 0%, 92%);
 $color-neutral-light-c: hsl(0, 0%, 88%);
-$color-neutral-light-d: hsl(0, 0%, 84%);
 $color-neutral-medium: hsl(0, 0%, 58%);
 $color-neutral-dark-a: hsl(0, 0%, 20%);
 $color-neutral-dark-b: hsl(0, 0%, 16%);


### PR DESCRIPTION
Disabled buttons used to employ this color variant but a slightly lighter one is currently in use.