### PR TITLE
Reorder color settings

### DIFF
--- a/source/settings/color.scss
+++ b/source/settings/color.scss
@@ -31,6 +31,10 @@ $color-negative-medium: hsl(8, 84%, 58%);
 $color-negative-dark-a: hsl(8, 88%, 34%);
 $color-negative-dark-b: hsl(8, 88%, 30%);
 
+// Focal
+
+$color-focal-regular: hsl(208, 100%, 42%);
+
 // Neutral
 
 $color-neutral-regular: hsl(0, 0%, 24%);
@@ -44,7 +48,3 @@ $color-neutral-dark-b: hsl(0, 0%, 16%);
 // White
 
 $color-white-regular: hsl(0, 0%, 100%);
-
-// Focal
-
-$color-focal-regular: hsl(208, 100%, 42%);


### PR DESCRIPTION
Define support colors, such as neutral and white, last because they are less likely to see change.