### PR TITLE
Define grid gaps directly

### DIFF
--- a/source/settings/layout.scss
+++ b/source/settings/layout.scss
@@ -7,20 +7,17 @@ $container-max-width: 1240px;
 
 // Grid
 
-$gap-regular: 1.25rem;
-$gap-large: 2.5rem;
-
 $grid-regular: (
   default: (
     column-count: 2,
-    gap: $gap-regular,
+    gap: 1.25rem,
   ),
   tablet: (
     column-count: 6,
   ),
   laptop: (
     column-count: 12,
-    gap: $gap-large,
+    gap: 2.5rem,
   ),
 );
 


### PR DESCRIPTION
Abstracting grid gap sizes is unnecessary because a single grid system is defined.