### PR TITLE
Remove visible focus outline directly

### DIFF
--- a/source/components/dialog.scss
+++ b/source/components/dialog.scss
@@ -13,7 +13,7 @@
   background-color: $color-white-regular;
 
   &:focus-visible {
-    @include focus-visible(none);
+    outline: 0;
   }
 
   &-heading {

--- a/source/helpers/focus-visible.scss
+++ b/source/helpers/focus-visible.scss
@@ -7,8 +7,6 @@
   @if ($style == "default") {
     outline: 3px solid $color-focal-regular;
     outline-offset: 3px;
-  } @else if ($style == "none") {
-    outline: 0;
   } @else {
     @error "Invalid visible focus style. Check spelling or review helper definition.";
   }


### PR DESCRIPTION
The browser defined outline can be easily removed at the component level, without requiring a separate visible focus helper style.