### PR TITLE
Detail Sass module paths

### DIFF
--- a/source/main.scss
+++ b/source/main.scss
@@ -1,33 +1,33 @@
 // BASICS
 // -----------------------------------------------------------------------------
 
-@use "basics/reset";
+@use "./basics/reset";
 
 // COMPONENTS
 // -----------------------------------------------------------------------------
 
-@use "components/accordion";
-@use "components/badge";
-@use "components/button";
-@use "components/card";
-@use "components/checkbox";
-@use "components/container";
-@use "components/dialog";
-@use "components/global-footer";
-@use "components/global-header";
-@use "components/grid";
-@use "components/heading";
-@use "components/link";
-@use "components/local-navigation";
-@use "components/menu";
-@use "components/notification";
-@use "components/radio";
-@use "components/switch";
-@use "components/table";
-@use "components/tabset";
-@use "components/textfield";
+@use "./components/accordion";
+@use "./components/badge";
+@use "./components/button";
+@use "./components/card";
+@use "./components/checkbox";
+@use "./components/container";
+@use "./components/dialog";
+@use "./components/global-footer";
+@use "./components/global-header";
+@use "./components/grid";
+@use "./components/heading";
+@use "./components/link";
+@use "./components/local-navigation";
+@use "./components/menu";
+@use "./components/notification";
+@use "./components/radio";
+@use "./components/switch";
+@use "./components/table";
+@use "./components/tabset";
+@use "./components/textfield";
 
 // UTILITIES
 // -----------------------------------------------------------------------------
 
-@use "utilities/no-scroll";
+@use "./utilities/no-scroll";


### PR DESCRIPTION
Identify the working directory when loading Sass modules or members in order to provide paths identical with those for importing JavaScript.