### PR TITLE
Change framework name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Ignition Vanilla
+# Lode Vanilla
 
-Build complex interfaces using a broad assortment of robust building blocks. Ignition Vanilla provides a coherent architecture, consistent naming conventions, and a large collection of elements and interface design patterns, that can be assembled to form web-based interfaces of any size or complexity.
+Build complex interfaces using a broad assortment of robust building blocks. Lode Vanilla provides a coherent architecture, consistent naming conventions, and a large collection of elements and interface design patterns, that can be assembled to form web-based interfaces of any size or complexity.
 
 ## Installation
 
-[Download the latest release](https://github.com/pixeltrove/ignition-vanilla/releases) or clone the repository using `git clone https://github.com/pixeltrove/ignition-vanilla.git`.
+[Download the latest release](https://github.com/pixeltrove/lode-vanilla/releases) or clone the repository using `git clone https://github.com/pixeltrove/lode-vanilla.git`.
 
 ## Copyright
 
-Copyright (c) 2021 [Mihnea-Luchian Cosma](https://github.com/luchian). Released under the [MIT License](https://github.com/pixeltrove/ignition-vanilla/blob/master/LICENSE.md).
+Copyright (c) 2021 [Mihnea-Luchian Cosma](https://github.com/luchian). Released under the [MIT License](https://github.com/pixeltrove/lode-vanilla/blob/master/LICENSE.md).

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "ignition-vanilla",
+  "name": "lode-vanilla",
   "version": "1.0.0",
   "description": "A broad assortment of robust interface building blocks.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixeltrove/ignition-vanilla.git"
+    "url": "https://github.com/pixeltrove/lode-vanilla.git"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
"Lode" is simpler, more unique, and better fits the Pixeltrove brand.